### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,10 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
   
   private
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new
@@ -21,9 +21,11 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
-  
+
   private
+
   def item_params
-    params.require(:item).permit(:name, :image, :describe, :price, :prefecture_id, :ship_fee_id, :ship_day_id, :status_id, :genre_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :image, :describe, :price, :prefecture_id, :ship_fee_id, :ship_day_id, :status_id,
+                                 :genre_id).merge(user_id: current_user.id)
   end
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,6 +1,6 @@
 class Genre < ActiveHash::Base
   self.data = [
-    { id: 0, name: '---' },  
+    { id: 0, name: '---' },
     { id: 1, name: 'レディース' },
     { id: 2, name: 'メンズ' },
     { id: 3, name: 'ベビー・キッズ' },
@@ -12,9 +12,7 @@ class Genre < ActiveHash::Base
     { id: 9, name: 'ハンドメイド' },
     { id: 10, name: 'その他' }
   ]
- 
-   include ActiveHash::Associations
-   has_many :items
- 
-  
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,7 @@ class Item < ApplicationRecord
   belongs_to :ship_fee
 
   validates :price, format: { with: /\A[0-9]+\z/ }
-  validates_numericality_of :price, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999
+  validates_numericality_of :price, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999
   with_options presence: true do
     validates :name
     validates :image
@@ -23,6 +23,5 @@ class Item < ApplicationRecord
       validates :status_id
       validates :ship_fee_id
     end
-   
   end
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,26 +1,24 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    {id: 0, name: '---'},
-    {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
-    {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
-    {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
-    {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
-    {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
-    {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
-    {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
-    {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
-    {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
-    {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
-    {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
-    {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
-    {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
-    {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
-    {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
-    {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
-]
+    { id: 0, name: '---' },
+    { id: 1, name: '北海道' }, { id: 2, name: '青森県' }, { id: 3, name: '岩手県' },
+    { id: 4, name: '宮城県' }, { id: 5, name: '秋田県' }, { id: 6, name: '山形県' },
+    { id: 7, name: '福島県' }, { id: 8, name: '茨城県' }, { id: 9, name: '栃木県' },
+    { id: 10, name: '群馬県' }, { id: 11, name: '埼玉県' }, { id: 12, name: '千葉県' },
+    { id: 13, name: '東京都' }, { id: 14, name: '神奈川県' }, { id: 15, name: '新潟県' },
+    { id: 16, name: '富山県' }, { id: 17, name: '石川県' }, { id: 18, name: '福井県' },
+    { id: 19, name: '山梨県' }, { id: 20, name: '長野県' }, { id: 21, name: '岐阜県' },
+    { id: 22, name: '静岡県' }, { id: 23, name: '愛知県' }, { id: 24, name: '三重県' },
+    { id: 25, name: '滋賀県' }, { id: 26, name: '京都府' }, { id: 27, name: '大阪府' },
+    { id: 28, name: '兵庫県' }, { id: 29, name: '奈良県' }, { id: 30, name: '和歌山県' },
+    { id: 31, name: '鳥取県' }, { id: 32, name: '島根県' }, { id: 33, name: '岡山県' },
+    { id: 34, name: '広島県' }, { id: 35, name: '山口県' }, { id: 36, name: '徳島県' },
+    { id: 37, name: '香川県' }, { id: 38, name: '愛媛県' }, { id: 39, name: '高知県' },
+    { id: 40, name: '福岡県' }, { id: 41, name: '佐賀県' }, { id: 42, name: '長崎県' },
+    { id: 43, name: '熊本県' }, { id: 44, name: '大分県' }, { id: 45, name: '宮崎県' },
+    { id: 46, name: '鹿児島県' }, { id: 47, name: '沖縄県' }
+  ]
 
-include ActiveHash::Associations
+  include ActiveHash::Associations
   has_many :items
-
-  
 end

--- a/app/models/ship_day.rb
+++ b/app/models/ship_day.rb
@@ -1,13 +1,11 @@
 class ShipDay < ActiveHash::Base
   self.data = [
     { id: 0, name: '---' },
-    { id: 1, name: '1~2日で発送' },  
+    { id: 1, name: '1~2日で発送' },
     { id: 2, name: '2~3日で発送' },
-    { id: 3, name: '4~7日で発送' },
+    { id: 3, name: '4~7日で発送' }
   ]
 
   include ActiveHash::Associations
-   has_many :items
-
-
+  has_many :items
 end

--- a/app/models/ship_fee.rb
+++ b/app/models/ship_fee.rb
@@ -1,12 +1,10 @@
 class ShipFee < ActiveHash::Base
   self.data = [
     { id: 0, name: '---' },
-    { id: 1, name: '着払い(購入者負担)' },  
-    { id: 2, name: '送料込み(出品者負担)' },
+    { id: 1, name: '着払い(購入者負担)' },
+    { id: 2, name: '送料込み(出品者負担)' }
   ]
 
   include ActiveHash::Associations
-   has_many :items
-
-
+  has_many :items
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,16 +1,14 @@
 class Status < ActiveHash::Base
   self.data = [
-    { id: 0, name: '---' },  
+    { id: 0, name: '---' },
     { id: 1, name: '新品、未使用' },
     { id: 2, name: '未使用に近い' },
     { id: 3, name: '目立った傷や汚れなし' },
     { id: 4, name: 'やや傷や汚れあり' },
     { id: 5, name: '傷や汚れあり' },
-    { id: 6, name: '全体的に状態が悪い' },
+    { id: 6, name: '全体的に状態が悪い' }
   ]
- 
-   include ActiveHash::Associations
-   has_many :items
- 
-  
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,17 +7,17 @@ class User < ApplicationRecord
   has_many :items
   has_many :purchases
   with_options presence: true do
-    validates :nickname       
+    validates :nickname
     validates :birth_day
     with_options format: { with: /\A[ぁ-んァ-ン一-龥]/ } do
-    validates :first_name 
-    validates :last_name
+      validates :first_name
+      validates :last_name
     end
     with_options format: { with: /\A[ァ-ヶー－]+\z/ } do
-    validates :first_name_kana
-    validates :last_name_kana
+      validates :first_name_kana
+      validates :last_name_kana
     end
   end
-    PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
-    validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'
+  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
+  validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%if @items.present? %>
       <% @items.each do |item| %>  
         <li class='list'>
-          <%= link_to  items_path do %>
+          <%= link_to  item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,19 +23,19 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id%>
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% elsif @item.present? %>
-        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        <%# //商品が売れていない場合はこちらを表示しましょう %>
+        
       <% end %>
     <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
 
     <div class="item-explain-box">
       <span><%= @item.describe %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price%>
       </span>
       <span class="item-postage">
         <%= @item.ship_fee.name %>
@@ -29,10 +29,8 @@
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-      <% elsif @item.present? %>
-        
+      <% else @item.present? %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        
       <% end %>
     <% end %>
     

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -19,51 +19,52 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.ship_fee.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id%>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% elsif @item.present? %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.describe %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.genre.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.ship_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.id %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.ship_day.id %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +104,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.genre.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -58,11 +58,11 @@
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.prefecture.id %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.ship_day.id %></td>
+          <td class="detail-value"><%= @item.ship_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-      <% else @item.present? %>
+      <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>
     <% end %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :item do
     name               { 'j' }
-    price              { 999999 }
+    price              { 999_999 }
     prefecture_id      { 1 }
     ship_day_id        { 2 }
     status_id          { 2 }
     describe           { 'j' }
     genre_id           { 2 }
     ship_fee_id        { 3 }
-    association :user 
-   
+    association :user
+
     after(:build) do |item|
       item.image.attach(io: File.open('app/assets/images/star.png'), filename: 'star.png')
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,105 +3,105 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   before do
     @item = FactoryBot.build(:item)
-end
+  end
 
-describe '商品の出品' do
-  context "商品の出品ができる場合" do
-    it "商品画像を1枚、商品名、商品の説明、カテゴリーの情報、商品の状態、配送料の負担、発送元の地域、発送までの日数、販売価格についての情報があれば保存できる" do
-      expect(@item).to be_valid
+  describe '商品の出品' do
+    context '商品の出品ができる場合' do
+      it '商品画像を1枚、商品名、商品の説明、カテゴリーの情報、商品の状態、配送料の負担、発送元の地域、発送までの日数、販売価格についての情報があれば保存できる' do
+        expect(@item).to be_valid
+      end
+    end
+    context '商品の出品ができない場合' do
+      it '商品画像が空では投稿できない' do
+        @item.image = nil
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Image can't be blank")
+      end
+      it '商品名が空では投稿できない' do
+        @item.name = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Name can't be blank")
+      end
+      it '商品の説明が空では投稿できない' do
+        @item.describe = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Describe can't be blank")
+      end
+      it 'カテゴリーの情報が空では投稿できない' do
+        @item.genre_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Genre can't be blank")
+      end
+      it '商品の状態が空では投稿できない' do
+        @item.status_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Status can't be blank")
+      end
+      it '配送料が空では投稿できない' do
+        @item.ship_fee_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Ship fee can't be blank", 'Ship fee is not a number')
+      end
+      it '発送元の地域が空では投稿できない' do
+        @item.prefecture_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+      end
+      it '発送までの日数が空では投稿できない' do
+        @item.ship_day_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Ship day can't be blank", 'Ship day is not a number')
+      end
+      it '販売価格が空では投稿できない' do
+        @item.price = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Price can't be blank")
+      end
+      it '販売価格は半角数字でなければ投稿できない' do
+        @item.price = '１２３４'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is not a number')
+      end
+      it '販売価格に数字以外が混じっていると投稿できない' do
+        @item.price = 'あいう'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is not a number')
+      end
+      it 'カテゴリーの情報が無効なidの場合投稿できない' do
+        @item.genre_id = 0
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Genre must be other than 0')
+      end
+      it '商品の状態の情報が無効なidの場合投稿できない' do
+        @item.status_id = 0
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Status must be other than 0')
+      end
+      it '配送料の情報が無効なidの場合投稿できない' do
+        @item.ship_fee_id = 0
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Ship fee must be other than 0')
+      end
+      it '発送元の情報が無効なidの場合投稿できない' do
+        @item.prefecture_id = 0
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Prefecture must be other than 0')
+      end
+      it '発送までの日数の情報が無効なidの場合投稿できない' do
+        @item.ship_day_id = 0
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Ship day must be other than 0')
+      end
+      it 'priceは300以下の場合登録できない' do
+        @item.price = 200
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
+      end
+      it 'priceは9,999,999以上の場合登録できない' do
+        @item.price = 1_000_000_000
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
+      end
     end
   end
-  context "商品の出品ができない場合" do
-    it "商品画像が空では投稿できない" do
-      @item.image = nil
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank")
-    end     
-    it "商品名が空では投稿できない" do
-      @item.name = ""
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Name can't be blank")
-    end     
-    it "商品の説明が空では投稿できない" do
-      @item.describe = ""
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Describe can't be blank")
-    end     
-    it "カテゴリーの情報が空では投稿できない" do
-      @item.genre_id = ""
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Genre can't be blank")
-    end     
-    it "商品の状態が空では投稿できない" do
-      @item.status_id = ""
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Status can't be blank")
-    end     
-    it "配送料が空では投稿できない" do
-      @item.ship_fee_id = ""
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Ship fee can't be blank", "Ship fee is not a number")
-    end     
-    it "発送元の地域が空では投稿できない" do
-      @item.prefecture_id = ""
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Prefecture can't be blank")
-    end     
-    it "発送までの日数が空では投稿できない" do
-      @item.ship_day_id = ""
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Ship day can't be blank", "Ship day is not a number")
-    end     
-    it "販売価格が空では投稿できない" do
-      @item.price = ""
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Price can't be blank")
-    end     
-    it "販売価格は半角数字でなければ投稿できない" do
-      @item.price = "１２３４"
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Price is not a number")
-    end   
-    it "販売価格に数字以外が混じっていると投稿できない" do
-      @item.price = "あいう"
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Price is not a number")
-    end    
-    it "カテゴリーの情報が無効なidの場合投稿できない" do
-      @item.genre_id = 0
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Genre must be other than 0")
-    end   
-    it "商品の状態の情報が無効なidの場合投稿できない" do
-    @item.status_id = 0
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Status must be other than 0")
-    end  
-    it "配送料の情報が無効なidの場合投稿できない" do
-    @item.ship_fee_id = 0
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Ship fee must be other than 0")
-    end    
-    it "発送元の情報が無効なidの場合投稿できない" do
-    @item.prefecture_id = 0
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Prefecture must be other than 0")
-    end  
-    it "発送までの日数の情報が無効なidの場合投稿できない" do
-    @item.ship_day_id = 0
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Ship day must be other than 0")
-    end     
-    it "priceは300以下の場合登録できない" do
-      @item.price = 200
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
-    end  
-    it "priceは9,999,999以上の場合登録できない" do
-      @item.price = 1000000000
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
-    end  
-  end
 end
-end 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe User, type: :model do
     it 'emailは@がついてないと登録できない' do
       @user.email = 'eee'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Email is invalid")
-  end
+      expect(@user.errors.full_messages).to include('Email is invalid')
+    end
     it 'passwordが空では登録できない' do
       @user.password = ''
       @user.valid?


### PR DESCRIPTION
# What
showへのパス設定、showアクションの設定、showのビューの修正

# Why
商品詳細表示機能

ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/56a95a7f03dd8e7079de794e3728ff6c

ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/9e6026a33eae0bab3d6cb390d002119a


https://gyazo.com/0ログアウト状態のユーザーが、商品詳細ページへ遷移した動画e032a1b8e5c8d80774eecd4c745606e

まだ商品購入機能を実装していないので、ログイン状態の出品者が、自身の出品した売却済み商品の詳細ページへ遷移した動画とログイン状態の出品者以外のユーザーが、他者の出品した売却済み商品の詳細ページへ遷移した動画はありません。